### PR TITLE
jumpfnc - Un-needed spawn?

### DIFF
--- a/Altis_Life.Altis/core/functions/fn_keyHandler.sqf
+++ b/Altis_Life.Altis/core/functions/fn_keyHandler.sqf
@@ -60,8 +60,7 @@ switch (_code) do {
 		if(isNil "jumpActionTime") then {jumpActionTime = 0;};
 		if(_shift && {!(EQUAL(animationState player,"AovrPercMrunSrasWrflDf"))} && {isTouchingGround player} && {EQUAL(stance player,"STAND")} && {speed player > 2} && {!life_is_arrested} && {SEL((velocity player),2) < 2.5} && {time - jumpActionTime > 1.5}) then {
 			jumpActionTime = time; //Update the time.
-			[player,true] spawn life_fnc_jumpFnc; //Local execution
-			[player,false] remoteExec ["life_fnc_jumpFnc",RANY]; //Global execution
+			[player] remoteExec ["life_fnc_jumpFnc",RANY]; //Global execution
 			_handled = true;
 		};
 	};

--- a/Altis_Life.Altis/core/functions/network/fn_jumpFnc.sqf
+++ b/Altis_Life.Altis/core/functions/network/fn_jumpFnc.sqf
@@ -7,11 +7,9 @@
 */
 private["_unit","_vel","_dir","_v1","_v2","_anim","_oldpos"];
 _unit = [_this,0,ObjNull,[ObjNull]] call BIS_fnc_param;
-_run = [_this,1,true,[false]] call BIS_fnc_param;
 _oldpos = getPosATL _unit;
 
 if(isNull _unit) exitWith {}; //Bad data
-if(local _unit && !_run) exitWith {}; //Ahh
 
 if(animationState _unit == "AovrPercMrunSrasWrflDf") exitWith {};
 


### PR DESCRIPTION
The idea here was to run jumpFnc on firstly the player, then sync the animation with everyone else except the player (filtered using a parameter). Why don't we just remove the run parameter? This will execute the script on every client and filter the player by where it is local, achieving the same exact thing.

I don't see a problem with this unless someone can shed some light on it I haven't considered.

Edit* Tested this and it works (syncs just fine)