### PR TITLE
fn_repairTruck: Added closeDialog 0;

### DIFF
--- a/Altis_Life.Altis/core/actions/fn_repairTruck.sqf
+++ b/Altis_Life.Altis/core/actions/fn_repairTruck.sqf
@@ -13,6 +13,7 @@ if (isNull _veh) exitWith {};
 if ((_veh isKindOf "Car") || (_veh isKindOf "Ship") || (_veh isKindOf "Air")) then {
     if (life_inv_toolkit > 0) then {
         life_action_inUse = true;
+        closeDialog 0;//Closes the interaction menu to prevent the player from being able to unflip the vehicle during repair.
         _displayName = FETCH_CONFIG2(getText,"CfgVehicles",(typeOf _veh),"displayName");
         _upp = format[localize "STR_NOTF_Repairing",_displayName];
 


### PR DESCRIPTION
##### Changes: 
- Added: `closeDialog 0;` 
  - Closes the interaction menu to prevent the player from being able to unflip the vehicle during repair. 

Tested and working. 
