### PR TITLE
Revert "Some optimization and stop autoclick - SellHouse"

### DIFF
--- a/Altis_Life.Altis/core/housing/fn_sellHouse.sqf
+++ b/Altis_Life.Altis/core/housing/fn_sellHouse.sqf
@@ -14,13 +14,10 @@ _uid = getPlayerUID player;
 if (isNull _house) exitWith {};
 if (!(_house isKindOf "House_F")) exitWith {};
 if (isNil {_house getVariable "house_owner"}) exitWith {hint localize "STR_House_noOwner";};
-if (playerSide != civilian) exitWith {hint "Only civilian.";}; // Only civilians can sell house.
 closeDialog 0;
 
 _houseCfg = [(typeOf _house)] call life_fnc_houseConfig;
 if (count _houseCfg isEqualTo 0) exitWith {};
-if ((time - life_action_delay) < 2) exitWith {hint localize "STR_NOTF_ActionDelay";}; // No glitch.
-life_action_delay = time;
 
 _action = [
     format[localize "STR_House_SellHouseMSG",


### PR DESCRIPTION
Reverts ArmaLife/Framework#727

Firstly, there is no proper issue relating to this, I'm still unsure what this is on about. If it's what I'm thinking, there is a better way of doing it, no to mention the string isn't localised. No more pulling random shit please.