### PR TITLE
House Storage Check

### DIFF
--- a/Altis_Life.Altis/core/items/fn_storageBox.sqf
+++ b/Altis_Life.Altis/core/items/fn_storageBox.sqf
@@ -10,6 +10,7 @@ private["_object","_attachPos"];
 params [
     ["_size",false,[false]]
 ];
+if (!(nearestObject [player, "House"] in life_vehicles)) exitWith {hint localize "STR_ISTR_Box_NotinHouse";};
 
 life_container_active = true;
 closeDialog 0;


### PR DESCRIPTION
Credits to BoGuu. I brought up the issue to him. He had the fix already... just was too lazy to commit it. Apparently Overwatch is more important. Lol.

Prevents people from pulling out the storage box in the open world and trying to slay others with it...